### PR TITLE
NiFi cluster hostname

### DIFF
--- a/deployment/nifi-ssl-configmap.yml
+++ b/deployment/nifi-ssl-configmap.yml
@@ -27,7 +27,7 @@ data:
     then
       echo "Creating keystore"
       keytool -genkey -noprompt -alias nifi-keystore \
-      -dname "CN=SA,OU=${ORGANISATION_UNIT},O=${ORGANISATION},L=${CITY},S=${STATE},C=${COUNTRY_CODE}" \
+      -dname "CN=${HOSTNAME},OU=${ORGANISATION_UNIT},O=${ORGANISATION},L=${CITY},S=${STATE},C=${COUNTRY_CODE}" \
       -keystore ${NIFI_HOME}/keytool/keystore.p12 \
       -storepass ${KEYSTORE_PASS:-$NIFI_SENSITIVE_PROPS_KEY} \
       -KeySize 2048 \
@@ -40,7 +40,7 @@ data:
     then
       echo "Creating truststore"
       keytool -genkey -noprompt -alias nifi-truststore \
-      -dname "CN=SA,OU=${ORGANISATION_UNIT},O=${ORGANISATION},L=${CITY},S=${STATE},C=${COUNTRY_CODE}" \
+      -dname "CN=${HOSTNAME},OU=${ORGANISATION_UNIT},O=${ORGANISATION},L=${CITY},S=${STATE},C=${COUNTRY_CODE}" \
       -keystore ${NIFI_HOME}/keytool/truststore.jks \
       -storetype jks \
       -keypass ${KEYSTORE_PASS:-$NIFI_SENSITIVE_PROPS_KEY} \

--- a/deployment/nifi.yml
+++ b/deployment/nifi.yml
@@ -23,6 +23,8 @@ spec:
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
+      setHostnameAsFQDN: true
+      dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
       securityContext:
         runAsGroup: 1000
@@ -74,26 +76,32 @@ spec:
         - containerPort: 6342
           name: cluster-lb
         env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP # Use pod ip
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name # Use pod name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace # Use pod namespace
+          - name: NIFI_UI_BANNER_TEXT
+            value: $(POD_NAME) # Use pod name for banner
           - name: NIFI_WEB_HTTP_HOST
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            value: $(POD_NAME).nifi.$(POD_NAMESPACE).svc.cluster.local # Use pod fqdn as web host
           - name: NIFI_CLUSTER_NODE_ADDRESS
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            value: $(POD_NAME).nifi.$(POD_NAMESPACE).svc.cluster.local # Use pod fqdn as node address
+          - name: NIFI_REMOTE_INPUT_SOCKET_HOST
+            value: $(POD_NAME).nifi.$(POD_NAMESPACE).svc.cluster.local # Use pod fqdn as input socket address
           - name: NIFI_REMOTE_INPUT_HOST
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            value: $(POD_NAME).nifi.$(POD_NAMESPACE).svc.cluster.local # Use pod fqdn as input host address
           - name: HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            value: $(POD_IP) # Use pod ip as hostname
           - name: NODE_IDENTITY
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+            value: $(POD_NAME) # Use pod name as identity
         envFrom:
           - configMapRef:
               name: nifi-cm

--- a/deployment/zookeeper.yml
+++ b/deployment/zookeeper.yml
@@ -23,6 +23,8 @@ spec:
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
+      setHostnameAsFQDN: true
+      dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
       securityContext:
         runAsGroup: 1000


### PR DESCRIPTION
This StatefulSet of Apache NiFi deployment uses hostname as reference in the cluster names. When Apache NiFi nodes/pods occasionally terminated and redeployed old zombie nodes/pods hostnames are still list in the cluster page and can not be removed, this will/should fix that bug
