### PR TITLE
feat: add zookeeper cluster mode

### DIFF
--- a/deployment/zookeeper-cluster/kustomization.yml
+++ b/deployment/zookeeper-cluster/kustomization.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  app.kubernetes.io/managed-by: kustomization
+
+resources:
+- service-client.yml
+- service-server.yml
+- zookeeper.yml
+
+# images:
+# - name: zookeeper
+#   newName: docker.io/zookeeper
+#   newTag: "3.8"

--- a/deployment/zookeeper-cluster/kustomization.yml
+++ b/deployment/zookeeper-cluster/kustomization.yml
@@ -9,8 +9,4 @@ resources:
 - service-client.yml
 - service-server.yml
 - zookeeper.yml
-
-# images:
-# - name: zookeeper
-#   newName: docker.io/zookeeper
-#   newTag: "3.8"
+- pdb.yml

--- a/deployment/zookeeper-cluster/pdb.yml
+++ b/deployment/zookeeper-cluster/pdb.yml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zookeeper
+  maxUnavailable: 1

--- a/deployment/zookeeper-cluster/service-client.yml
+++ b/deployment/zookeeper-cluster/service-client.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper-client
+  labels:
+    app.kubernetes.io/name: zookeeper
+    app.kubernetes.io/part-of: nifi
+spec:
+  ports:
+  - port: 2181
+    name: client
+  selector:
+    app.kubernetes.io/name: zookeeper

--- a/deployment/zookeeper-cluster/service-server.yml
+++ b/deployment/zookeeper-cluster/service-server.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper-server
+  labels:
+    app.kubernetes.io/name: zookeeper
+    app.kubernetes.io/part-of: nifi
+spec:
+  ports:
+  - port: 2888
+    name: server
+  - port: 3888
+    name: leader-election
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: zookeeper

--- a/deployment/zookeeper-cluster/zookeeper.yml
+++ b/deployment/zookeeper-cluster/zookeeper.yml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zookeeper
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zookeeper
+  serviceName: zookeeper-server
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: OrderedReady
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zookeeper
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app.kubernetes.io/name"
+                    operator: In
+                    values:
+                    - zookeeper
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: zookeeper
+        imagePullPolicy: Always
+        image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "0.5"
+        ports:
+        - containerPort: 2181
+          name: client
+        - containerPort: 2888
+          name: server
+        - containerPort: 3888
+          name: leader-election
+        command:
+        - sh
+        - -c
+        - "start-zookeeper \
+          --servers=3 \
+          --data_dir=/var/lib/zookeeper/data \
+          --data_log_dir=/var/lib/zookeeper/data/log \
+          --conf_dir=/opt/zookeeper/conf \
+          --client_port=2181 \
+          --election_port=3888 \
+          --server_port=2888 \
+          --tick_time=2000 \
+          --init_limit=10 \
+          --sync_limit=5 \
+          --heap=512M \
+          --max_client_cnxns=60 \
+          --snap_retain_count=3 \
+          --purge_interval=12 \
+          --max_session_timeout=40000 \
+          --min_session_timeout=4000 \
+          --log_level=INFO"
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - "zookeeper-ready 2181"
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - "zookeeper-ready 2181"
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/zookeeper
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      volumes:
+        - name: data
+          emptyDir:
+            sizeLimit: 2Gi

--- a/deployment/zookeeper-cluster/zookeeper.yml
+++ b/deployment/zookeeper-cluster/zookeeper.yml
@@ -30,10 +30,6 @@ spec:
       - name: zookeeper
         imagePullPolicy: Always
         image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
-        resources:
-          requests:
-            memory: "1Gi"
-            cpu: "0.5"
         ports:
         - containerPort: 2181
           name: client
@@ -78,6 +74,20 @@ spec:
             - "zookeeper-ready 2181"
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 200m
+            memory: 500Mi
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
         - name: data
           mountPath: /var/lib/zookeeper

--- a/deployment/zookeeper-cluster/zookeeper.yml
+++ b/deployment/zookeeper-cluster/zookeeper.yml
@@ -91,6 +91,10 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/zookeeper
+          subPath: zookeeper
+        - name: data
+          mountPath: /opt/zookeeper/conf
+          subPath: conf
       securityContext:
         runAsUser: 1000
         fsGroup: 1000


### PR DESCRIPTION
This will deploy zookeeper in cluster mode:
- 3x Apache Zookeeper (accessible within the cluster only)
- 2 Services (1 cluster communication, 1 client connection)
- **Must have minimum of 4 nodes in K8s cluster**

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- [x] New feature (non-breaking change which adds functionality)
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->
- Resolves: #35 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation. ⚠️ 
- [ ] I have updated the documentation accordingly. ⚠️ 
- [x] I've read the [CONTRIBUTION](../CONTRIBUTING.md) guide
- [x] I have added CI tests to cover my changes.
- [x] All new and existing tests passed.
