### PR TITLE
Using HTTPS to access NiFi Web URL since NiFi 2.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ NiFi runs HTTPS-only. With an nginx Ingress controller, access it via the Ingres
 kubectl port-forward svc/nifi 8443:8443 -n nifi  # fallback without ingress
 ```
 
-Then open: [http://nifi/nifi](http://nifi/nifi)
+Then open: [https://nifi/nifi](https://nifi/nifi)
 
 NiFi handles its own authentication - log in with the single-user credentials configured in `configmap.yml`.
 


### PR DESCRIPTION
## What this PR does / why we need it:

- Changing into current NiFi Web UI URL with protocol.
- Since the NiFi 2.x is released, the NiFi Web URL should use `HTTPS`. The user session should be expired if using the `HTTP` to try to login the web interface.
- The related reference is [here](https://blog.davidvassallo.me/2020/03/23/nugget-post-running-nifi-behind-an-ssl-reverse-proxy/).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Doc

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](../CONTRIBUTING.md) guide
- [ ] I have added CI tests to cover my changes.
- [ ] All new and existing tests passed.
